### PR TITLE
Feat save system

### DIFF
--- a/Assets/Scripts/CreateBuilding.cs
+++ b/Assets/Scripts/CreateBuilding.cs
@@ -38,7 +38,7 @@ public class CreateBuilding: MonoBehaviour
     {
         print("Button Clicked");
         Instantiate(buildingPrefab);
-        buildingPrefab.transform.position = new Vector3(x, 0.5f, z);
+        buildingPrefab.transform.position = new Vector3(x - 4.5f, 0.5f, z - 4.5f);
         buildingPrefab.GetComponent<BuildingScript>().mainCam = MainCam;
         buildingPrefab.GetComponent<BuildingScript>().mainGrid = MainGrid;
     }

--- a/Assets/Scripts/CreateBuilding.cs
+++ b/Assets/Scripts/CreateBuilding.cs
@@ -36,7 +36,7 @@ public class CreateBuilding: MonoBehaviour
 
     public void createBuilding(float x, float z)
     {
-        print("Button Clicked");
+        print($"Building Being placed at {x}, {z}");
         Instantiate(buildingPrefab);
         buildingPrefab.transform.position = new Vector3(x - 4.5f, 0.5f, z - 4.5f);
         buildingPrefab.GetComponent<BuildingScript>().mainCam = MainCam;

--- a/Assets/Scripts/SavingReloading.meta
+++ b/Assets/Scripts/SavingReloading.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c13eea5913e14e1ab15b62e0d702115a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SavingReloading/SaveSystem.cs
+++ b/Assets/Scripts/SavingReloading/SaveSystem.cs
@@ -11,9 +11,9 @@ namespace SavingReloading
         private float lastSaveTime;
         private float lastLoadTime;
         private string savePath;
-        const string FileName = "save.data";
+        const string GridDataSaveFileName = "grid_data_save.data";
         GridSystem gridSystem;
-        private CreateBuilding creator;
+        private CreateBuilding buildingCreator;
 
 
         private void Start()
@@ -21,7 +21,7 @@ namespace SavingReloading
             savePath = Application.persistentDataPath;
             gridSystem = FindObjectOfType<GridSystem>();
             lastSaveTime = Time.time;
-            creator = FindObjectOfType<CreateBuilding>();
+            buildingCreator = FindObjectOfType<CreateBuilding>();
             // Let them load their data right on startup.
             // See LoadSaveData() for explanation.
             lastLoadTime = Time.time - 5.0f;
@@ -52,7 +52,7 @@ namespace SavingReloading
 
         private void LoadSaveData()
         {
-            string path = Path.Combine(savePath, FileName);
+            string path = Path.Combine(savePath, GridDataSaveFileName);
             using StreamReader reader = new StreamReader(path);
             string fmt = reader.ReadLine();
 
@@ -86,7 +86,7 @@ namespace SavingReloading
                     if (isFilled == 1)
                     {
                         gridSystem.fillCell(x, z);
-                        creator.createBuilding(x, z);
+                        buildingCreator.createBuilding(x, z);
                     }
                     else
                     {
@@ -99,7 +99,7 @@ namespace SavingReloading
 
         private void SaveCurrent()
         {
-            string path = Path.Combine(savePath, FileName);
+            string path = Path.Combine(savePath, GridDataSaveFileName);
             using StreamWriter writer = new StreamWriter(path, false);
             writer.WriteLine($"x,y=zone_type,is_filled");
             foreach (UInt32 z in Enumerable.Range(0, gridSystem.height))
@@ -110,7 +110,6 @@ namespace SavingReloading
                     int cellFilled = gridSystem.isCellFilled((int)x, (int)z) ? 1 : 0;
                     string output =
                         $"{x},{z}={zoneType},{cellFilled}";
-                    Debug.Log(output);
                     writer.WriteLine(output);
                 }
             }

--- a/Assets/Scripts/SavingReloading/SaveSystem.cs
+++ b/Assets/Scripts/SavingReloading/SaveSystem.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace SavingReloading
+{
+    public class SaveSystem : MonoBehaviour
+    {
+        private float lastSaveTime;
+        private float lastLoadTime;
+        private string savePath;
+        const string FileName = "save.data";
+        GridSystem gridSystem;
+        private CreateBuilding creator;
+
+
+        private void Start()
+        {
+            savePath = Application.persistentDataPath;
+            gridSystem = FindObjectOfType<GridSystem>();
+            lastSaveTime = Time.time;
+            creator = FindObjectOfType<CreateBuilding>();
+            // Let them load their data right on startup.
+            // See LoadSaveData() for explanation.
+            lastLoadTime = Time.time - 5.0f;
+            Assert.IsTrue(gridSystem != null);
+        }
+
+        private void Update()
+        {
+            // Most of the time, they just won't be holding control,
+            // so return to prevent extra work.
+            if (!Input.GetKey(KeyCode.LeftControl)) return;
+
+            // Can't save or load multiple times within 5 seconds
+            bool s = Input.GetKey(KeyCode.T) && ((Time.time - lastSaveTime) > 5.0f);
+            bool l = Input.GetKey(KeyCode.L) && ((Time.time - lastLoadTime) > 5.0f);
+
+            if (s)
+            {
+                lastSaveTime = Time.time;
+                SaveCurrent();
+            }
+            else if (l)
+            {
+                lastLoadTime = Time.time;
+                LoadSaveData();
+            }
+        }
+
+        private void LoadSaveData()
+        {
+            string path = Path.Combine(savePath, FileName);
+            using StreamReader reader = new StreamReader(path);
+            string fmt = reader.ReadLine();
+
+            Assert.AreEqual(fmt, "x,y=zone_type,is_filled");
+
+            foreach (var z in Enumerable.Range(0, gridSystem.height))
+            {
+                foreach (var x in Enumerable.Range(0, gridSystem.width))
+                {
+                    string[] coordToValue = reader.ReadLine()?.Split('=');
+                    if (coordToValue == null) return;
+                    // Debug.Log($"coordToValue = \"{coordToValue[0]}, {coordToValue[1]}\"");
+
+                    string[] coords = coordToValue[0].Split(',');
+                    Assert.IsNotNull(coords);
+                    Assert.IsTrue(coords.Length == 2);
+                    // Debug.Log($"coords = \"{coords[0]}, {coords[1]}\"");
+                    
+                    int cellX = int.Parse(coords[0]);
+                    int cellY = int.Parse(coords[1]);
+                    Assert.AreEqual(cellX, x);
+                    Assert.AreEqual(cellY, z);
+
+                    string[] zoneTypeAndIsFilled = coordToValue[1].Split(',');
+                    Assert.IsNotNull(zoneTypeAndIsFilled);
+                    Assert.IsTrue(zoneTypeAndIsFilled.Length == 2);
+                    // Debug.Log($"zoneTypeAndIsFilled = \"{zoneTypeAndIsFilled[0]}, {zoneTypeAndIsFilled[1]}\"");
+                    
+                    ZoneType zoneType = (ZoneType)int.Parse(zoneTypeAndIsFilled[0]);
+                    int isFilled = int.Parse(zoneTypeAndIsFilled[1]);
+                    if (isFilled == 1)
+                    {
+                        gridSystem.fillCell(x, z);
+                        creator.createBuilding(x, z);
+                    }
+                    else
+                    {
+                        gridSystem.emptyCell(x, z);
+                    }
+                    gridSystem.SetZone(x, z, zoneType);
+                }
+            }
+        }
+
+        private void SaveCurrent()
+        {
+            string path = Path.Combine(savePath, FileName);
+            using StreamWriter writer = new StreamWriter(path, false);
+            writer.WriteLine($"x,y=zone_type,is_filled");
+            foreach (UInt32 z in Enumerable.Range(0, gridSystem.height))
+            {
+                foreach (UInt32 x in Enumerable.Range(0, gridSystem.width))
+                {
+                    var zoneType = (int)gridSystem.GetZoneType((int)x, (int)z);
+                    int cellFilled = gridSystem.isCellFilled((int)x, (int)z) ? 1 : 0;
+                    string output =
+                        $"{x},{z}={zoneType},{cellFilled}";
+                    Debug.Log(output);
+                    writer.WriteLine(output);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/SavingReloading/SaveSystem.cs.meta
+++ b/Assets/Scripts/SavingReloading/SaveSystem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 92ebe9e0781340c6b4915c0cf916eb67
+timeCreated: 1740265684


### PR DESCRIPTION
Save Grid Data, like building placement and zones, with Control + T. Creates save file if it's not there, or overwrites it if it is there. 
Load Grid Data with Control + L. This places the buildings down, but the alignment is off because of a recent update. We will need to fix that.