### PR TITLE
Cell improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 # JetBrains Editor Configuration
 .idea
 
+# Default FPS Settings
+ProjectSettings/TimelineSettings.asset
+
 # Visual Studio cache directory
 .vs/
 

--- a/Assets/Scenes/Graham_Test_Scene.unity
+++ b/Assets/Scenes/Graham_Test_Scene.unity
@@ -661,7 +661,7 @@ GameObject:
   - component: {fileID: 645938367}
   - component: {fileID: 645938366}
   m_Layer: 5
-  m_Name: BuildingButton
+  m_Name: ModeButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -72,7 +72,15 @@ public class Cell : MonoBehaviour
         }
     }
 
-    public static void BTN_ToBuildingMode()
+    public static void CycleZoneType()
+    {
+        Cell.paintbrush++;
+        if (Cell.paintbrush > ZoneType.Restricted)
+        {
+            Cell.paintbrush = ZoneType.Residential;
+        }
+    }
+    public static void CycleBuildingMode()
     {
         Cell.building_mode++;
         if (Cell.building_mode >= BuildingMode.TotalModes)
@@ -85,7 +93,6 @@ public class Cell : MonoBehaviour
     {
         zone_type = zt;
         color = GridSystem.ZoneColor(zone_type);
-        /*renderer ??= gameObject.GetComponent<Renderer>();*/
         renderer.material.color = color;
     }
 
@@ -110,9 +117,15 @@ public class Cell : MonoBehaviour
         Building.building_positions.Add(this.transform.position);
     }
 
+    public bool Removable()
+    {
+        return cell_type != CellType.None;
+    }
+
     public bool Buildable()
     {
-        return zone_type != ZoneType.Restricted;
+        return zone_type != ZoneType.Restricted
+            && cell_type == CellType.None;
     }
 
     public void PushRoad(Color color)

--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -30,6 +30,8 @@ public class Cell : MonoBehaviour
     public CellType cell_type;
     public bool walkable;
 
+    public GameObject contents;
+
     public void SetWalkableAndUpdate(bool is_walkable)
     {
         walkable = is_walkable;
@@ -96,70 +98,125 @@ public class Cell : MonoBehaviour
         renderer.material.color = color;
     }
 
-    public void PushBuilding(Color color)
+    private bool _TryPushBuilding()
     {
-        if (zone_type == ZoneType.Restricted) return;
+        if (contents != null) return false;
+
         cell_type = CellType.Building;
-        this.color = color;
-        creator.createBuilding(location.x, location.y, color, zone_type, cell_type);
+        contents = creator.createBuilding(location.x, location.y, color, zone_type, cell_type);
         SetWalkableAndUpdate(true);
 
         Building.building_positions.Add(this.transform.position);
+
+        return contents != null;
     }
 
-    public void PushBuilding()
+    public bool TryPushBuilding(Color color)
     {
-        if (zone_type == ZoneType.Restricted) return;
-        cell_type = CellType.Building;
-        creator.createBuilding(location.x, location.y, color, zone_type, cell_type);
-        SetWalkableAndUpdate(true);
+        if (!Buildable()) return false;
+        this.color = color;
+        return _TryPushBuilding();
+    }
 
-        Building.building_positions.Add(this.transform.position);
+    public bool TryPushBuilding()
+    {
+        return Buildable() && _TryPushBuilding();
     }
 
     public bool Removable()
     {
-        return cell_type != CellType.None;
+        return cell_type != CellType.None
+            && contents != null;
     }
 
     public bool Buildable()
     {
         return zone_type != ZoneType.Restricted
-            && cell_type == CellType.None;
+            && cell_type == CellType.None
+            && contents == null;
     }
 
-    public void PushRoad(Color color)
+    private bool _TryPushRoad()
     {
-        if (zone_type == ZoneType.Restricted) return;
+        cell_type = CellType.Road;
+        contents = creator.createBuilding(location.x, location.y, color, zone_type, cell_type);
+        SetWalkableAndUpdate(true);
+
+        return contents != null;
+    }
+
+    public bool TryPushRoad(Color color)
+    {
+        if (!Buildable()) return false;
         this.color = color;
-        cell_type = CellType.Road;
-        creator.createBuilding(location.x, location.y, color, zone_type, cell_type);
-        SetWalkableAndUpdate(true);
+        return _TryPushRoad();
     }
 
-    public void PushRoad()
+    public bool TryPushRoad()
     {
-        if (zone_type == ZoneType.Restricted) return;
-        cell_type = CellType.Road;
-        creator.createBuilding(location.x, location.y, color, zone_type, cell_type);
-        SetWalkableAndUpdate(true);
+        return Buildable() && _TryPushRoad();
+    }
+
+    public static void RemoveContents(Cell c)
+    {
+        if (!c.Removable())
+        {
+            print($"Can't remove at: {c.location}");
+            return;
+        }
+        print($"Removing {c.contents}...");
+
+        c.SetCellTypeAndUpdate(CellType.None);
+        bool r = Building.building_positions.Remove(c.gameObject.transform.position)
+            || Building.building_positions.Remove(c.transform.position);
+        print($"{(r ? "Removed" : "Couldn't Remove")}");
+        Destroy(c.contents);
+        c.contents = null;
+    }
+
+    public void RemoveContents()
+    {
+        if (!Removable())
+        {
+            print($"Can't remove at: {location}");
+            return;
+        }
+        print($"Removing {hovering.contents}...");
+
+        creator.destroyBuilding(hovering.contents);
+        hovering.contents = null;
     }
 
     public void SetCellTypeAndUpdate(CellType ct)
     {
         if (ct == CellType.Building)
         {
-            PushBuilding();
+            TryPushBuilding();
         }
         else if (ct == CellType.Road)
         {
-            PushRoad();
+            TryPushRoad();
         }
         else
         {
             cell_type = ct;
             SetWalkableAndUpdate(false);
         }
+    }
+
+    public static Cell AtCoords(Vector2Int loc)
+    {
+        return all_cells[loc.y + (loc.x * grid.width)];
+    }
+
+    public static GameObject ContentsAtCoords(Vector2Int loc)
+    {
+        return grid.GetCellAt(loc.x, loc.y);
+    }
+
+    public static GameObject ContentsAtCoords(int x, int z)
+    {
+        return grid.GetCellAt(x, z);
     }
 
     public static Cell AtCoords(int x, int z)
@@ -169,7 +226,11 @@ public class Cell : MonoBehaviour
 
     public override string ToString()
     {
-        return JsonUtility.ToJson(this, true);
+        int zt = (int)zone_type;
+        int ct = (int)cell_type;
+        int x = location.x;
+        int z = location.y;
+        return $"{x},{z}={zt},{ct}";
     }
 
     private void OnMouseEnter()
@@ -181,7 +242,6 @@ public class Cell : MonoBehaviour
             last_hovered.SetZoneTypeAndUpdate(last_hovered.zone_type);
             return;
         }
-        Debug.Log($"transform.rotation = {gameObject.transform.rotation}");
         hovering = this;
 
         if (building_mode == BuildingMode.MarkingZoneType)
@@ -284,27 +344,28 @@ public class Cell : MonoBehaviour
             grid_tile.GetComponent<Cell>().SetZoneTypeAndUpdate(paintbrush);
             SetZoneTypeAndUpdate(paintbrush);
         }
-        else if (building_mode == BuildingMode.None)
-        {
-            SetWalkableAndUpdate(false);
-        }
+        /*else if (building_mode == BuildingMode.None)*/
+        /*{*/
+        /*    SetWalkableAndUpdate(false);*/
+        /*}*/
         else
         {
-            if (Buildable())
+            switch (building_mode)
             {
-                switch (building_mode)
-                {
-                    case BuildingMode.PlacingBuilding:
-                        grid.fillCell(hovering.location.x, hovering.location.y);
-                        PushBuilding(GridSystem.ZoneColor(zone_type));
-                        break;
-                    case BuildingMode.PlacingRoad:
-                        grid.fillCell(hovering.location.x, hovering.location.y);
-                        PushRoad(GridSystem.ZoneColor(zone_type));
-                        break;
-                    default:
-                        break;
-                }
+                case BuildingMode.PlacingBuilding:
+                    TryPushBuilding(GridSystem.ZoneColor(zone_type));
+                    break;
+
+                case BuildingMode.PlacingRoad:
+                    TryPushRoad(GridSystem.ZoneColor(zone_type));
+                    break;
+
+                case BuildingMode.Removal:
+                    RemoveContents(AtCoords(hovering.location));
+                    break;
+
+                default:
+                    break;
             }
         }
     }

--- a/Assets/Scripts/Citizens/Building.cs
+++ b/Assets/Scripts/Citizens/Building.cs
@@ -28,20 +28,20 @@ namespace Citizens
             building_positions.Add(tracked);
         }
 
-        public void RequestUpdate()
-        {
-            GridSystem grid = GameObject.Find("Grid").GetComponent<GridSystem>();
-            List<GameObject> cells = grid.GetCells();
-            building_positions.Clear();
-            foreach (var cell in cells)
-            {
-                Cell c = cell.GetComponent<Cell>();
-                if (c.cell_type == CellType.Building)
-                {
-                    building_positions.Add(c.gameObject.transform.position);
-                }
-            }
-        }
+        /*public void RequestUpdate()*/
+        /*{*/
+        /*    GridSystem grid = GameObject.Find("Grid").GetComponent<GridSystem>();*/
+        /*    List<GameObject> cells = grid.GetCells();*/
+        /*    building_positions.Clear();*/
+        /*    foreach (var cell in cells)*/
+        /*    {*/
+        /*        Cell c = cell.GetComponent<Cell>();*/
+        /*        if (c.cell_type == CellType.Building)*/
+        /*        {*/
+        /*            building_positions.Add(c.gameObject.transform.position);*/
+        /*        }*/
+        /*    }*/
+        /*}*/
 
         public void UpdateCitizens()
         {
@@ -68,10 +68,10 @@ namespace Citizens
         // Update is called once per frame
         void Update()
         {
-            if (Input.GetKeyDown(KeyCode.B))
-            {
-                RequestUpdate();
-            }
+            /*if (Input.GetKeyDown(KeyCode.B))*/
+            /*{*/
+            /*    RequestUpdate();*/
+            /*}*/
         }
 
         void FixedUpdate()

--- a/Assets/Scripts/CreateBuilding.cs
+++ b/Assets/Scripts/CreateBuilding.cs
@@ -84,7 +84,15 @@ public class CreateBuilding : MonoBehaviour
         c.SetZoneTypeAndUpdate(zone_type);
     }
 
-    public void createBuilding(float x, float z, Color color, ZoneType zone_type, CellType cell_type)
+    public void destroyBuilding(GameObject go)
+    {
+        var g = prefabs.Find((GameObject g) => { return Object.ReferenceEquals(g, go); });
+        if (g is null) return;
+        prefabs.Remove(g);
+        Destroy(g);
+    }
+
+    public GameObject createBuilding(float x, float z, Color color, ZoneType zone_type, CellType cell_type)
     {
         print($"CreateBuilding: {x}, {z}, {color}, {zone_type}, {cell_type}");
         var next_prefab = getCellTypeShape(cell_type);
@@ -97,6 +105,7 @@ public class CreateBuilding : MonoBehaviour
             applyRoadShapeTransformations(next_prefab, zone_type, (int)x, (int)z);
         }
         prefabs.Add(next_prefab);
+        return next_prefab;
     }
 
     public void createBuilding(float x, float z, Color color, ZoneType zone_type)

--- a/Assets/Scripts/Danny/NPCMovement.cs
+++ b/Assets/Scripts/Danny/NPCMovement.cs
@@ -16,7 +16,10 @@ namespace Danny
             if (!SpawnManager.spawned_and_moving)
             {
                 agent = GetComponent<NavMeshAgent>();
-                agent.radius /= 10.0f;
+                // I don't know why, but 0.25f doesn't work here
+                // the same way it does in SpawnManager.
+                // 0.025f works, though.
+                agent.radius = 0.025f;
                 agent.acceleration /= 10.0f;
                 agent.speed /= 10.0f;
                 agent.updateRotation = true;

--- a/Assets/Scripts/Danny/SpawnManager.cs
+++ b/Assets/Scripts/Danny/SpawnManager.cs
@@ -66,7 +66,6 @@ namespace Danny
                     nma.radius = 0.025f;
                     nma.acceleration /= 10.0f;
                     nma.speed /= 10.0f;
-
                     nma.updateRotation = true;
                     nma.autoRepath = true;
                     Citizen.go_citizens.Add(npc);

--- a/Assets/Scripts/Danny/SpawnManager.cs
+++ b/Assets/Scripts/Danny/SpawnManager.cs
@@ -63,7 +63,7 @@ namespace Danny
 
                     Assert.IsTrue(nma.Warp(positions[i]));
                     Assert.IsTrue(nma.SetDestination(destinations[i]));
-                    nma.radius /= 10.0f;
+                    nma.radius = 0.25f;
                     nma.acceleration /= 10.0f;
                     nma.speed /= 10.0f;
                     nma.updateRotation = true;

--- a/Assets/Scripts/Danny/SpawnManager.cs
+++ b/Assets/Scripts/Danny/SpawnManager.cs
@@ -63,9 +63,10 @@ namespace Danny
 
                     Assert.IsTrue(nma.Warp(positions[i]));
                     Assert.IsTrue(nma.SetDestination(destinations[i]));
-                    nma.radius = 0.25f;
+                    nma.radius = 0.025f;
                     nma.acceleration /= 10.0f;
                     nma.speed /= 10.0f;
+
                     nma.updateRotation = true;
                     nma.autoRepath = true;
                     Citizen.go_citizens.Add(npc);

--- a/Assets/Scripts/GridSystem.cs
+++ b/Assets/Scripts/GridSystem.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Citizens;
-using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.UI;
@@ -195,7 +194,6 @@ public class GridSystem : MonoBehaviour
 
     }
 
-    [CanBeNull]
     public List<GameObject> GetBuildings()
     {
         if (filledCells is null || gridCells is null) return null;
@@ -217,7 +215,6 @@ public class GridSystem : MonoBehaviour
         return buildings;
     }
 
-    [CanBeNull]
     public List<GameObject> GetCells()
     {
         if (filledCells is null || gridCells is null) return null;

--- a/Assets/Scripts/GridSystem.cs
+++ b/Assets/Scripts/GridSystem.cs
@@ -62,8 +62,8 @@ public class GridSystem : MonoBehaviour
 
     void Awake()
     {
-        BTN_change_building_mode = GameObject.Find("BuildingButton").GetComponent<Button>();
-        BTN_change_building_mode.onClick.AddListener(Cell.BTN_ToBuildingMode);
+        BTN_change_building_mode = GameObject.Find("ModeButton").GetComponent<Button>();
+        BTN_change_building_mode.onClick.AddListener(Cell.CycleBuildingMode);
     }
 
     /// Initializes the grid arrays and generates the grid structure
@@ -177,23 +177,13 @@ public class GridSystem : MonoBehaviour
 
         if (e)
         {
-            Cell.building_mode++;
-            if (Cell.building_mode >= BuildingMode.TotalModes)
-            {
-                Cell.building_mode = BuildingMode.None;
-            }
+            Cell.CycleBuildingMode();
         }
 
         if (r)
         {
-            print($"Paintbrush = {Cell.paintbrush}");
-            Cell.paintbrush++;
-            if (Cell.paintbrush > ZoneType.Restricted)
-            {
-                Cell.paintbrush = ZoneType.Residential;
-            }
+            Cell.CycleZoneType();
         }
-
 
         uiText.GetComponent<TMPro.TextMeshProUGUI>().text =
             $"Simulation Time: {SimCore.Instance.simulationClock}\n" +

--- a/Assets/Scripts/GridSystem.cs
+++ b/Assets/Scripts/GridSystem.cs
@@ -19,6 +19,7 @@ public enum BuildingMode
     PlacingBuilding,
     PlacingRoad,
     MarkingZoneType,
+    Removal,
 
     // Always keep TotalModes at the end
     TotalModes
@@ -137,9 +138,9 @@ public class GridSystem : MonoBehaviour
                 }
 
                 // Add thin collider for mouse interaction
-                BoxCollider collide = cell.AddComponent<BoxCollider>();
-                // The name "collider" was causing conflicts
-                collide.size = new Vector3(1, 1, 0.1f);
+                /*BoxCollider collide = cell.AddComponent<BoxCollider>();*/
+                /*// The name "collider" was causing conflicts*/
+                /*collide.size = new Vector3(1, 1, 0.1f);*/
 
                 // Store reference to cell
                 gridCells[x, z] = cell;
@@ -184,13 +185,31 @@ public class GridSystem : MonoBehaviour
             Cell.CycleZoneType();
         }
 
-        uiText.GetComponent<TMPro.TextMeshProUGUI>().text =
-            $"Simulation Time: {SimCore.Instance.simulationClock}\n" +
-            $"Cell: {(Cell.hovering is null ? "N/A" : Cell.hovering.location)}\n" +
-            $"Zone Type: {(Cell.hovering is null ? "N/A" : Cell.hovering.zone_type)}\n" +
-            $"Paintbrush: {Cell.paintbrush}\n" +
-            $"Building Placement Mode: {Cell.building_mode}\n" +
-            $"Number of Buildings: {Building.building_positions.Count}";
+        if (SimCore.Instance.view_mode == SimCore.ViewMode.Default)
+        {
+            if (Cell.hovering is not null)
+                uiText.GetComponent<TMPro.TextMeshProUGUI>().text =
+                    $"Simulation Time: {SimCore.Instance.simulationClock}\n" +
+                    $"Cell: {(Cell.hovering.location)}\n" +
+                    $"Occupied: {(Cell.AtCoords(Cell.hovering.location).contents)}\n" +
+                    $"Zone Type: {(Cell.hovering.zone_type)}\n" +
+                    $"Paintbrush: {Cell.paintbrush}\n" +
+                    $"Building Placement Mode: {Cell.building_mode}\n" +
+                    $"Number of Buildings: {Building.building_positions.Count}";
+            else
+                uiText.GetComponent<TMPro.TextMeshProUGUI>().text =
+                    $"Simulation Time: {SimCore.Instance.simulationClock}\n" +
+                    $"Cell: N/A\n" +
+                    $"Occupied: N/A\n" +
+                    $"Zone Type: N/A\n" +
+                    $"Paintbrush: {Cell.paintbrush}\n" +
+                    $"Building Placement Mode: {Cell.building_mode}\n" +
+                    $"Number of Buildings: {Building.building_positions.Count}";
+        }
+        else
+        {
+            uiText.GetComponent<TMPro.TextMeshProUGUI>().text = "";
+        }
 
     }
 

--- a/Assets/Scripts/SimCore.cs
+++ b/Assets/Scripts/SimCore.cs
@@ -1,5 +1,6 @@
 using Citizens;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class SimCore : MonoBehaviour
 {
@@ -14,6 +15,9 @@ public class SimCore : MonoBehaviour
     private float simulationSpeed = 1f;
     private float simulationTimer = 0f;
     private float updateInterval = 1f; // One second intervals
+
+    private Button pauseSimulationButton;
+    private Button playSimulationButton;
 
     public float simulationClock = 0f;
 
@@ -36,6 +40,8 @@ public class SimCore : MonoBehaviour
             Destroy(gameObject);
         }
 
+        playSimulationButton = GameObject.Find("PLAY").GetComponent<Button>();
+        pauseSimulationButton = GameObject.Find("Pause").GetComponent<Button>();
     }
 
     void Start()
@@ -57,6 +63,10 @@ public class SimCore : MonoBehaviour
         isSimulationRunning = true;
         Citizen.EnableMovement(true);
         Debug.Log("Simulation Started");
+        playSimulationButton.targetGraphic.color = Color.green;
+        pauseSimulationButton.targetGraphic.color = Color.red;
+        pauseSimulationButton.enabled = true;
+        playSimulationButton.enabled = false;
     }
 
     public void PauseSimulation()
@@ -64,6 +74,10 @@ public class SimCore : MonoBehaviour
         isSimulationRunning = false;
         Citizen.EnableMovement(false);
         Debug.Log("Simulation Paused");
+        pauseSimulationButton.targetGraphic.color = Color.green;
+        playSimulationButton.targetGraphic.color = Color.red;
+        pauseSimulationButton.enabled = false;
+        playSimulationButton.enabled = true;
     }
 
     public void SetSimulationSpeed(float speed)

--- a/Assets/Scripts/SimCore.cs
+++ b/Assets/Scripts/SimCore.cs
@@ -21,6 +21,16 @@ public class SimCore : MonoBehaviour
 
     public float simulationClock = 0f;
 
+    public enum ViewMode
+    {
+        Default,
+        Clear,
+
+        TotalViewModes,
+    }
+
+    public ViewMode view_mode;
+
     private enum SimState
     {
         Initializing,
@@ -55,6 +65,15 @@ public class SimCore : MonoBehaviour
     {
         if (isSimulationRunning)
             simulationClock += Time.unscaledDeltaTime * simulationSpeed;
+        if (Input.GetKeyDown(KeyCode.V))
+            CycleViewModes();
+    }
+
+    private void CycleViewModes()
+    {
+        view_mode++;
+        if (view_mode >= ViewMode.TotalViewModes)
+            view_mode = ViewMode.Default;
     }
 
     // Time Control Methods


### PR DESCRIPTION
You can remove buildings now. It sometimes messes up the Citizen Navigation but will be fixed with the upcoming Proper Citizen Implementation.

Other:
Pause and Play buttons now alternate in color to show which is active and usable.
Press V to change the ViewMode in SimCore to "Clear", which clears the text on the screen.
Citizen radius now more accurately reflects the size of the actual citizen models.