### PR TITLE
Feat citizen impl

### DIFF
--- a/Assets/Scripts/CameraControls.cs
+++ b/Assets/Scripts/CameraControls.cs
@@ -129,8 +129,10 @@ public class CameraControls : MonoBehaviour
 
     private void UpdateRotation()
     {
-        currentYaw = Mathf.LerpAngle(currentYaw, targetYaw, rotationSmoothness);
-        currentPitch = Mathf.LerpAngle(currentPitch, targetPitch, rotationSmoothness);
+        float dt_rotationSmoothness = (rotationSmoothness * Time.unscaledDeltaTime) * 100f;
+
+        currentYaw = Mathf.LerpAngle(currentYaw, targetYaw, dt_rotationSmoothness);
+        currentPitch = Mathf.LerpAngle(currentPitch, targetPitch, dt_rotationSmoothness);
         transform.rotation = Quaternion.Euler(currentPitch, currentYaw, 0);
     }
 

--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -174,19 +174,6 @@ public class Cell : MonoBehaviour
         c.contents = null;
     }
 
-    public void RemoveContents()
-    {
-        if (!Removable())
-        {
-            print($"Can't remove at: {location}");
-            return;
-        }
-        print($"Removing {hovering.contents}...");
-
-        creator.destroyBuilding(hovering.contents);
-        hovering.contents = null;
-    }
-
     public void SetCellTypeAndUpdate(CellType ct)
     {
         if (ct == CellType.Building)

--- a/Assets/Scripts/Citizens/Building.cs
+++ b/Assets/Scripts/Citizens/Building.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
-using UnityEngine.AI;
-using UnityEngine.Assertions;
+/*using UnityEngine.AI;*/
+/*using UnityEngine.Assertions;*/
 
 namespace Citizens
 {
@@ -18,10 +18,10 @@ namespace Citizens
             building_positions = new List<Vector3>();
         }
 
-        public void AddCitizen(GameObject go_citizen)
-        {
-            Citizen.go_citizens.Add(go_citizen);
-        }
+        /*public void AddCitizen(GameObject go_citizen)*/
+        /*{*/
+        /*    Citizen.go_citizens.Add(go_citizen);*/
+        /*}*/
 
         public static void TrackPosition(Vector3 tracked)
         {
@@ -43,20 +43,20 @@ namespace Citizens
         /*    }*/
         /*}*/
 
-        public void UpdateCitizens()
-        {
-            int mod = building_positions.Count;
-            foreach (var citizen in Citizens.Citizen.go_citizens)
-            {
-                var nma = citizen.GetComponent<NavMeshAgent>();
-                Assert.IsTrue(nma.isOnNavMesh);
-                if (nma.remainingDistance < 0.25f)
-                {
-                    int rand = Random.Range(0, mod);
-                    nma.SetDestination(building_positions[rand]);
-                }
-            }
-        }
+        /*public void UpdateCitizens()*/
+        /*{*/
+        /*    int mod = building_positions.Count;*/
+        /*    foreach (var citizen in Citizens.Citizen.go_citizens)*/
+        /*    {*/
+        /*        var nma = citizen.GetComponent<NavMeshAgent>();*/
+        /*        Assert.IsTrue(nma.isOnNavMesh);*/
+        /*        if (nma.remainingDistance < 0.25f)*/
+        /*        {*/
+        /*            int rand = Random.Range(0, mod);*/
+        /*            nma.SetDestination(building_positions[rand]);*/
+        /*        }*/
+        /*    }*/
+        /*}*/
 
         // Start is called before the first frame update
         void Start()
@@ -76,14 +76,14 @@ namespace Citizens
 
         void FixedUpdate()
         {
-            if (SimCore.Instance.sim_state == SimState.Running && Citizen.citizens_enabled)
-            {
-                if (Time.unscaledTime - last_citizen_update > 5.0f)
-                {
-                    last_citizen_update = Time.unscaledTime;
-                    UpdateCitizens();
-                }
-            }
+            /*if (SimCore.Instance.sim_state == SimState.Running && Citizen.citizens_enabled)*/
+            /*{*/
+            /*    if (Time.unscaledTime - last_citizen_update > 5.0f)*/
+            /*    {*/
+            /*        last_citizen_update = Time.unscaledTime;*/
+            /*        UpdateCitizens();*/
+            /*    }*/
+            /*}*/
         }
     }
 }

--- a/Assets/Scripts/Citizens/Building.cs
+++ b/Assets/Scripts/Citizens/Building.cs
@@ -18,45 +18,10 @@ namespace Citizens
             building_positions = new List<Vector3>();
         }
 
-        /*public void AddCitizen(GameObject go_citizen)*/
-        /*{*/
-        /*    Citizen.go_citizens.Add(go_citizen);*/
-        /*}*/
-
         public static void TrackPosition(Vector3 tracked)
         {
             building_positions.Add(tracked);
         }
-
-        /*public void RequestUpdate()*/
-        /*{*/
-        /*    GridSystem grid = GameObject.Find("Grid").GetComponent<GridSystem>();*/
-        /*    List<GameObject> cells = grid.GetCells();*/
-        /*    building_positions.Clear();*/
-        /*    foreach (var cell in cells)*/
-        /*    {*/
-        /*        Cell c = cell.GetComponent<Cell>();*/
-        /*        if (c.cell_type == CellType.Building)*/
-        /*        {*/
-        /*            building_positions.Add(c.gameObject.transform.position);*/
-        /*        }*/
-        /*    }*/
-        /*}*/
-
-        /*public void UpdateCitizens()*/
-        /*{*/
-        /*    int mod = building_positions.Count;*/
-        /*    foreach (var citizen in Citizens.Citizen.go_citizens)*/
-        /*    {*/
-        /*        var nma = citizen.GetComponent<NavMeshAgent>();*/
-        /*        Assert.IsTrue(nma.isOnNavMesh);*/
-        /*        if (nma.remainingDistance < 0.25f)*/
-        /*        {*/
-        /*            int rand = Random.Range(0, mod);*/
-        /*            nma.SetDestination(building_positions[rand]);*/
-        /*        }*/
-        /*    }*/
-        /*}*/
 
         // Start is called before the first frame update
         void Start()
@@ -68,22 +33,10 @@ namespace Citizens
         // Update is called once per frame
         void Update()
         {
-            /*if (Input.GetKeyDown(KeyCode.B))*/
-            /*{*/
-            /*    RequestUpdate();*/
-            /*}*/
         }
 
         void FixedUpdate()
         {
-            /*if (SimCore.Instance.sim_state == SimState.Running && Citizen.citizens_enabled)*/
-            /*{*/
-            /*    if (Time.unscaledTime - last_citizen_update > 5.0f)*/
-            /*    {*/
-            /*        last_citizen_update = Time.unscaledTime;*/
-            /*        UpdateCitizens();*/
-            /*    }*/
-            /*}*/
         }
     }
 }

--- a/Assets/Scripts/Citizens/Building.cs
+++ b/Assets/Scripts/Citizens/Building.cs
@@ -76,7 +76,7 @@ namespace Citizens
 
         void FixedUpdate()
         {
-            if (SimCore.Instance.isSimulationRunning && Citizen.citizens_enabled)
+            if (SimCore.Instance.sim_state == SimState.Running && Citizen.citizens_enabled)
             {
                 if (Time.unscaledTime - last_citizen_update > 5.0f)
                 {

--- a/Assets/Scripts/Citizens/Citizen.cs
+++ b/Assets/Scripts/Citizens/Citizen.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
-using Danny;
+/*using Danny;*/
 using UnityEngine;
 using UnityEngine.AI;
+/*using UnityEngine.Assertions;*/
 
 namespace Citizens
 {
@@ -21,78 +22,81 @@ namespace Citizens
         public const float acceleration = 0.8f;
         public const float angular_speed = 120f;
         public const float area_cost = 1f;
+        public const float set_speed = 0.1f;
     }
 
 
     public class Citizen : MonoBehaviour
     {
         public static bool citizens_enabled = false;
-        public static List<GameObject> go_citizens = new List<GameObject>();
+        /*public static List<GameObject> go_citizens = new List<GameObject>();*/
 
         private static List<NavMeshAgent> nma_citizens = new List<NavMeshAgent>();
 
-        // The concern right now is getting things to work.
-        // Performance comes later.
-        private static Vector3[] velocities = new Vector3[100];
-
+        private float last_clock_update;
+        private static float dest_update_interval = 1.0f;
 
         NavMeshAgent agent;
 
         public CitizenModel prefab_idx;
 
+        public Citizen with_destination(Vector3 destination)
+        {
+            agent.SetDestination(destination);
+            return this;
+        }
+
+        public Citizen with_enabled_movement(bool enabled)
+        {
+            agent.isStopped = !enabled;
+            return this;
+        }
+
+        public Citizen with_position(Vector3 position)
+        {
+            agent.Warp(position);
+            return this;
+        }
+
+        public Citizen with_model(CitizenModel model)
+        {
+            prefab_idx = model;
+            return this;
+        }
 
         public static void ClearCitizens()
         {
-            foreach (var citizen in go_citizens)
+            foreach (var citizen in nma_citizens)
             {
-                Destroy(citizen);
+                Destroy(citizen.gameObject);
             }
-            go_citizens.Clear();
-            go_citizens = new List<GameObject>();
+            nma_citizens.Clear();
+            nma_citizens = null;
         }
-
 
         public static void EnableMovement(bool is_enabled)
         {
-            var idx = 0;
-            foreach (var citizen in go_citizens)
+            foreach (var citizen in nma_citizens)
             {
-
-                var nma = citizen.GetComponent<NavMeshAgent>();
-                nma_citizens.Add(nma);
-
-                nma.isStopped = !is_enabled;
-                if (nma.isStopped)
-                {
-                    velocities[idx++] = nma.velocity;
-                    nma.velocity = Vector3.zero;
-                    nma.speed = 0f;
-                    nma.acceleration = 0f;
-                    nma.updateRotation = false;
-
-                    SpawnManager.spawned_and_moving = false;
-                    Citizen.citizens_enabled = false;
-                }
-                else
-                {
-                    nma.velocity = velocities[idx++];
-                    nma.speed = DefaultCitizenInfo.speed;
-                    nma.acceleration = DefaultCitizenInfo.acceleration;
-                    nma.angularSpeed = DefaultCitizenInfo.angular_speed;
-                    nma.updateRotation = false;
-
-                    SpawnManager.spawned_and_moving = true;
-                    Citizen.citizens_enabled = true;
-                }
+                citizen.isStopped = !is_enabled;
             }
         }
 
 
         private void Awake()
         {
+            nma_citizens ??= new List<NavMeshAgent>();
+
             agent = GetComponent<NavMeshAgent>();
             agent.updateUpAxis = true;
             agent.updatePosition = true;
+            agent.updateRotation = false;
+
+            agent.speed = DefaultCitizenInfo.speed;
+            agent.acceleration = DefaultCitizenInfo.acceleration;
+            agent.angularSpeed = DefaultCitizenInfo.angular_speed;
+            nma_citizens.Add(agent);
+            last_clock_update = SimCore.Instance.simulationClock;
         }
 
 
@@ -100,16 +104,50 @@ namespace Citizens
         {
         }
 
-        private void Update()
+        private void UpdateRotation()
+        {
+            curr_dest = agent.steeringTarget;
+            agent.transform.LookAt(agent.steeringTarget);
+        }
+
+        private void UpdateDestinationAndClock()
+        {
+            last_clock_update = SimCore.Instance.simulationClock;
+
+            if (agent.remainingDistance < 0.25f)
+            {
+                int rand = Random.Range(0, Building.building_positions.Count);
+                agent.SetDestination(Building.building_positions[rand]);
+            }
+        }
+
+        Vector3 curr_dest;
+        private void FixedUpdate()
         {
             if (SimCore.Instance.sim_state == SimState.Running)
             {
+                if (SimCore.Instance.simulationClock
+                    - last_clock_update
+                    > dest_update_interval)
+                {
+                    UpdateDestinationAndClock();
+                }
+
+
                 agent.transform.position =
                     Vector3.MoveTowards(
-                        agent.transform.position,
-                        agent.steeringTarget,
-                        0.01f * SimCore.Instance.SimSpeed);
+                    agent.transform.position,
+                    agent.steeringTarget,
+                    DefaultCitizenInfo.set_speed * SimCore.Instance.SimSpeed
+                    );
+
+                if (curr_dest != agent.steeringTarget)
+                    UpdateRotation();
             }
+        }
+
+        private void Update()
+        {
         }
     }
 }

--- a/Assets/Scripts/Citizens/Citizen.cs
+++ b/Assets/Scripts/Citizens/Citizen.cs
@@ -12,6 +12,7 @@ namespace Citizens
         female_dress,
         male_casual,
         male_suit,
+
         CITIZEN_MODELS_MAX
     }
 
@@ -20,16 +21,19 @@ namespace Citizens
         public CitizenModel model_type;
     }
 
+    public class DefaultCitizenInfo
+    {
+        public const float speed = 0.35f;
+        public const float acceleration = 0.8f;
+        public const float angular_speed = 120f;
+        public const float area_cost = 1f;
+    }
+
 
     public class Citizen : MonoBehaviour
     {
         public static bool citizens_enabled = false;
         public static List<GameObject> go_citizens = new List<GameObject>();
-
-        public static Cell CitizenCellLocation(Vector3 position)
-        {
-            return new Cell();
-        }
 
         public static void ClearCitizens()
         {
@@ -41,6 +45,28 @@ namespace Citizens
             go_citizens = new List<GameObject>();
         }
 
+        public static void SetSpeedCitizens(float adjust)
+        {
+            if (adjust <= 0f)
+            {
+                throw new UnityException($"Can't call SetSpeedCitizens with {adjust}!");
+            }
+            foreach (var citizen in go_citizens)
+            {
+                /*var nma = citizen.GetComponent<NavMeshAgent>();*/
+                /*nma.speed = DefaultCitizenInfo.speed * adjust;*/
+                /*nma.acceleration = DefaultCitizenInfo.acceleration * adjust;*/
+                /*nma.angularSpeed = DefaultCitizenInfo.angular_speed;*/
+                /*nma.stoppingDistance = 0f;*/
+                /*nma.autoBraking = true;*/
+                var anim = citizen.GetComponent<Animator>();
+                anim.logWarnings = true;
+                anim.SetLookAtPosition(Vector3.up * 100f);
+                print(anim.isMatchingTarget);
+                print(anim.isInitialized);
+            }
+        }
+
         // The concern right now is getting things to work.
         // Performance comes later.
         private static Vector3[] velocities = new Vector3[100];
@@ -50,6 +76,7 @@ namespace Citizens
             var idx = 0;
             foreach (var citizen in go_citizens)
             {
+
                 var nma = citizen.GetComponent<NavMeshAgent>();
                 nma.isStopped = !is_enabled;
                 if (nma.isStopped)
@@ -58,12 +85,19 @@ namespace Citizens
                     nma.velocity = Vector3.zero;
                     nma.speed = 0f;
                     nma.acceleration = 0f;
+                    nma.updateRotation = false;
+
                     SpawnManager.spawned_and_moving = false;
                     Citizen.citizens_enabled = false;
-                } else {
+                }
+                else
+                {
                     nma.velocity = velocities[idx++];
-                    nma.speed = 0.35f;
-                    nma.acceleration = 0.8f;
+                    nma.speed = DefaultCitizenInfo.speed;
+                    nma.acceleration = DefaultCitizenInfo.acceleration;
+                    nma.angularSpeed = DefaultCitizenInfo.angular_speed;
+                    nma.updateRotation = false;
+
                     SpawnManager.spawned_and_moving = true;
                     Citizen.citizens_enabled = true;
                 }

--- a/Assets/Scripts/Citizens/Citizen.cs
+++ b/Assets/Scripts/Citizens/Citizen.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Danny;
 using UnityEngine;
@@ -16,11 +15,6 @@ namespace Citizens
         CITIZEN_MODELS_MAX
     }
 
-    public struct CitizenInfo
-    {
-        public CitizenModel model_type;
-    }
-
     public class DefaultCitizenInfo
     {
         public const float speed = 0.35f;
@@ -35,6 +29,18 @@ namespace Citizens
         public static bool citizens_enabled = false;
         public static List<GameObject> go_citizens = new List<GameObject>();
 
+        private static List<NavMeshAgent> nma_citizens = new List<NavMeshAgent>();
+
+        // The concern right now is getting things to work.
+        // Performance comes later.
+        private static Vector3[] velocities = new Vector3[100];
+
+
+        NavMeshAgent agent;
+
+        public CitizenModel prefab_idx;
+
+
         public static void ClearCitizens()
         {
             foreach (var citizen in go_citizens)
@@ -45,31 +51,6 @@ namespace Citizens
             go_citizens = new List<GameObject>();
         }
 
-        public static void SetSpeedCitizens(float adjust)
-        {
-            if (adjust <= 0f)
-            {
-                throw new UnityException($"Can't call SetSpeedCitizens with {adjust}!");
-            }
-            foreach (var citizen in go_citizens)
-            {
-                /*var nma = citizen.GetComponent<NavMeshAgent>();*/
-                /*nma.speed = DefaultCitizenInfo.speed * adjust;*/
-                /*nma.acceleration = DefaultCitizenInfo.acceleration * adjust;*/
-                /*nma.angularSpeed = DefaultCitizenInfo.angular_speed;*/
-                /*nma.stoppingDistance = 0f;*/
-                /*nma.autoBraking = true;*/
-                var anim = citizen.GetComponent<Animator>();
-                anim.logWarnings = true;
-                anim.SetLookAtPosition(Vector3.up * 100f);
-                print(anim.isMatchingTarget);
-                print(anim.isInitialized);
-            }
-        }
-
-        // The concern right now is getting things to work.
-        // Performance comes later.
-        private static Vector3[] velocities = new Vector3[100];
 
         public static void EnableMovement(bool is_enabled)
         {
@@ -78,6 +59,8 @@ namespace Citizens
             {
 
                 var nma = citizen.GetComponent<NavMeshAgent>();
+                nma_citizens.Add(nma);
+
                 nma.isStopped = !is_enabled;
                 if (nma.isStopped)
                 {
@@ -104,14 +87,29 @@ namespace Citizens
             }
         }
 
+
+        private void Awake()
+        {
+            agent = GetComponent<NavMeshAgent>();
+            agent.updateUpAxis = true;
+            agent.updatePosition = true;
+        }
+
+
         private void Start()
         {
-            throw new NotImplementedException();
         }
 
         private void Update()
         {
-            throw new NotImplementedException();
+            if (SimCore.Instance.sim_state == SimState.Running)
+            {
+                agent.transform.position =
+                    Vector3.MoveTowards(
+                        agent.transform.position,
+                        agent.steeringTarget,
+                        0.01f * SimCore.Instance.SimSpeed);
+            }
         }
     }
 }

--- a/Assets/Scripts/Citizens/Citizen.cs
+++ b/Assets/Scripts/Citizens/Citizen.cs
@@ -29,14 +29,12 @@ namespace Citizens
     public class Citizen : MonoBehaviour
     {
         public static bool citizens_enabled = false;
-        /*public static List<GameObject> go_citizens = new List<GameObject>();*/
 
         private static List<NavMeshAgent> nma_citizens = new List<NavMeshAgent>();
-
         private float last_clock_update;
         private static float dest_update_interval = 1.0f;
 
-        NavMeshAgent agent;
+        private NavMeshAgent agent;
 
         public CitizenModel prefab_idx;
 

--- a/Assets/Scripts/Danny/SpawnManager.cs
+++ b/Assets/Scripts/Danny/SpawnManager.cs
@@ -77,7 +77,7 @@ namespace Danny
                 }
             }
 
-            if (SimCore.Instance.isSimulationRunning)
+            if (SimCore.Instance.sim_state == SimState.Running)
             {
                 Citizen.EnableMovement(true);
             }

--- a/Assets/Scripts/Danny/SpawnManager.cs
+++ b/Assets/Scripts/Danny/SpawnManager.cs
@@ -55,11 +55,14 @@ namespace Danny
                 npc.name = citizen_names[i];
                 npc.tag = "Citizens";
 
+
                 // Ensure the animator is enabled
                 Animator npcAnimator = npc.GetComponent<Animator>();
                 if (npcAnimator is not null)
                 {
                     var nma = npc.GetComponent<NavMeshAgent>();
+                    Citizen citizen = npc.AddComponent<Citizen>();
+                    citizen.prefab_idx = (CitizenModel)prefab_index;
 
                     Assert.IsTrue(nma.Warp(positions[i]));
                     Assert.IsTrue(nma.SetDestination(destinations[i]));

--- a/Assets/Scripts/Danny/SpawnManager.cs
+++ b/Assets/Scripts/Danny/SpawnManager.cs
@@ -1,9 +1,7 @@
-using System.Collections.Generic;
 using Citizens;
-/*using Unity.AI.Navigation;*/
 using UnityEngine;
-using UnityEngine.AI;
-using UnityEngine.Assertions;
+/*using UnityEngine.AI;*/
+/*using UnityEngine.Assertions;*/
 using UnityEngine.UI;
 
 namespace Danny
@@ -32,62 +30,32 @@ namespace Danny
             npcButton.onClick = null;
             npcButton.enabled = false;
 
-            if (Citizen.go_citizens is not null
-                &&
-                Citizen.go_citizens.Count > 0)
-            {
-                Citizen.ClearCitizens();
-            }
-            else
-            {
-                Citizen.go_citizens = new List<GameObject>(npcCount);
-            }
-
-
             for (int i = 0; i < npcCount; i++)
             {
                 string[] name_id_index = citizen_names[i].Split('_');
-                int prefab_index = int.Parse(name_id_index[2]);
+                CitizenModel prefab_index = CitizenModel.Parse<CitizenModel>(name_id_index[2]);
                 GameObject npc =
-                    Instantiate(npcPrefabs[prefab_index],
+                    Instantiate(npcPrefabs[((int)prefab_index)],
                             positions[i],
                             Quaternion.identity);
                 npc.name = citizen_names[i];
                 npc.tag = "Citizens";
 
-
-                // Ensure the animator is enabled
-                Animator npcAnimator = npc.GetComponent<Animator>();
-                if (npcAnimator is not null)
-                {
-                    var nma = npc.GetComponent<NavMeshAgent>();
-                    Citizen citizen = npc.AddComponent<Citizen>();
-                    citizen.prefab_idx = (CitizenModel)prefab_index;
-
-                    Assert.IsTrue(nma.Warp(positions[i]));
-                    Assert.IsTrue(nma.SetDestination(destinations[i]));
-                    nma.radius = 0.025f;
-                    nma.acceleration /= 10.0f;
-                    nma.speed /= 10.0f;
-                    nma.updateRotation = true;
-                    nma.autoRepath = true;
-                    Citizen.go_citizens.Add(npc);
-
-                }
-                else
+                if (npc is null)
                 {
                     throw new UnityException("NPCAnimator was null");
                 }
+
+                Citizen citizen = npc.AddComponent<Citizen>()
+                    .with_model(prefab_index)
+                    .with_position(positions[i])
+                    .with_destination(destinations[i])
+                    .with_enabled_movement(
+                            SimCore.Instance.sim_state
+                            == SimState.Running);
             }
 
-            if (SimCore.Instance.sim_state == SimState.Running)
-            {
-                Citizen.EnableMovement(true);
-            }
-            else
-            {
-                Citizen.EnableMovement(false);
-            }
+            Citizen.citizens_enabled = true;
         }
 
         public void SpawnNPCs()
@@ -99,7 +67,6 @@ namespace Danny
             npcButton.interactable = false;
             npcButton.onClick = null;
             npcButton.enabled = false;
-            Citizen.go_citizens = new List<GameObject>(npcCount);
 
             for (int i = 0; i < npcCount; i++)
             {
@@ -117,17 +84,12 @@ namespace Danny
 
                 npc.tag = "Citizens";
 
-                // Ensure the animator is enabled
-                Animator npcAnimator = npc.GetComponent<Animator>();
-                if (npcAnimator is not null)
-                {
-                    // npcAnimator.SetTrigger("Idle"); // Ensure NPC starts animating
-                    Citizen.go_citizens.Add(npc);
-                }
-                else
-                {
-                    throw new UnityException("NPCAnimator was null");
-                }
+                Citizen citizen = npc.AddComponent<Citizen>()
+                    .with_model((CitizenModel)rand_prefab_idx)
+                    .with_position(Building.building_positions[rand_position_idx])
+                    .with_enabled_movement(
+                            SimCore.Instance.sim_state
+                            == SimState.Running);
             }
 
             Citizen.citizens_enabled = true;

--- a/Assets/Scripts/GridSystem.cs
+++ b/Assets/Scripts/GridSystem.cs
@@ -185,7 +185,7 @@ public class GridSystem : MonoBehaviour
             Cell.CycleZoneType();
         }
 
-        if (SimCore.Instance.view_mode == SimCore.ViewMode.Default)
+        if (SimCore.Instance.view_mode == ViewMode.Default)
         {
             if (Cell.hovering is not null)
                 uiText.GetComponent<TMPro.TextMeshProUGUI>().text =

--- a/Assets/Scripts/SavingReloading/SaveSystem.cs
+++ b/Assets/Scripts/SavingReloading/SaveSystem.cs
@@ -49,26 +49,8 @@ namespace SavingReloading
             }
             else if (l)
             {
-                // Bandaid solution for loading.
-                // Double the work but for some reason,
-                // NavMeshAgent doesn't want to comply
-                // the first time around. 
-                //
-                // It works just fine the second time.
-                //
-                // I don't know why.
-                //
-                // TODO: Fix this abomination.
-                /*if (first_load)*/
-                /*{*/
-                /*    first_load = false;*/
-                /*    LoadAllData();*/
-                /*}*/
-                /*else*/
-                /*{*/
                 lastLoadTime = Time.time;
                 LoadAllData();
-                /*}*/
             }
         }
 

--- a/Assets/Scripts/SavingReloading/SaveSystem.cs
+++ b/Assets/Scripts/SavingReloading/SaveSystem.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using Citizens;
 using Danny;
-using Unity.AI.Navigation;
 using UnityEngine;
 using UnityEngine.AI;
 using UnityEngine.Assertions;
@@ -15,12 +14,9 @@ namespace SavingReloading
         private string savePath;
 
         const string GridDataSaveFileName = "grid_data_save.data";
-
-        // const string RoadDataSaveFileName = "road_data_save.data";
         const string CitizenDataSaveFileName = "citizen_data_save.data";
         GridSystem gridSystem;
         private CreateBuilding creator;
-
 
         private void Start()
         {
@@ -144,17 +140,6 @@ namespace SavingReloading
             if (spawner is null)
             {
                 throw new UnityException("Why was SpawnManager null when trying to load NPCs?");
-            }
-            {
-                NavMeshSurface[] surfaces = GameObject.FindObjectsOfType<NavMeshSurface>();
-                if (surfaces is null)
-                {
-                    throw new UnityException("NavMeshSurface was null");
-                }
-                else
-                {
-                    Debug.Log($"# surfaces = {surfaces.Length}, go = {JsonUtility.ToJson(surfaces)}");
-                }
             }
 
             for (int i = 0; i < SpawnManager.npcCount; i++)

--- a/Assets/Scripts/SimCore.cs
+++ b/Assets/Scripts/SimCore.cs
@@ -82,7 +82,10 @@ public class SimCore : MonoBehaviour
     void Update()
     {
         if (sim_state == SimState.Running)
+        {
             simulationClock += Time.unscaledDeltaTime * simulationSpeed;
+        }
+
         if (Input.GetKeyDown(KeyCode.V))
             CycleViewModes();
 
@@ -97,13 +100,11 @@ public class SimCore : MonoBehaviour
     {
         simulationSpeed *= 0.5f;
         simulationSpeed = Mathf.Clamp(simulationSpeed, 0.03125f, 32.0f);
-        Citizen.SetSpeedCitizens(simulationSpeed);
     }
     private void IncreaseSimulationSpeed()
     {
         simulationSpeed *= 2.0f;
         simulationSpeed = Mathf.Clamp(simulationSpeed, 0.03125f, 32.0f);
-        Citizen.SetSpeedCitizens(simulationSpeed);
     }
 
     private void CycleSimulationStates()

--- a/Assets/Scripts/SimCore.cs
+++ b/Assets/Scripts/SimCore.cs
@@ -2,6 +2,24 @@ using Citizens;
 using UnityEngine;
 using UnityEngine.UI;
 
+
+public enum SimState
+{
+    Default,
+    Running = Default,
+    Paused,
+
+    TotalSimStates,
+}
+
+public enum ViewMode
+{
+    Default,
+    Clear,
+
+    TotalViewModes,
+}
+
 public class SimCore : MonoBehaviour
 {
     // Singleton pattern for easy access
@@ -14,28 +32,28 @@ public class SimCore : MonoBehaviour
     public bool isSimulationRunning = false;
     private float simulationSpeed = 1f;
     private float simulationTimer = 0f;
-    private float updateInterval = 1f; // One second intervals
 
     private Button pauseSimulationButton;
     private Button playSimulationButton;
 
     public float simulationClock = 0f;
 
-    public enum ViewMode
-    {
-        Default,
-        Clear,
 
-        TotalViewModes,
+    public float SimSpeed
+    {
+        get { return simulationSpeed; }
     }
 
-    public ViewMode view_mode;
-
-    private enum SimState
+    public ViewMode view_mode
     {
-        Initializing,
-        Running,
-        Paused
+        get;
+        private set;
+    }
+
+    public SimState sim_state
+    {
+        get;
+        private set;
     }
 
     void Awake()
@@ -63,10 +81,36 @@ public class SimCore : MonoBehaviour
 
     void Update()
     {
-        if (isSimulationRunning)
+        if (sim_state == SimState.Running)
             simulationClock += Time.unscaledDeltaTime * simulationSpeed;
         if (Input.GetKeyDown(KeyCode.V))
             CycleViewModes();
+
+        if (Input.GetKeyDown(KeyCode.F))
+            IncreaseSimulationSpeed();
+
+        if (Input.GetKeyDown(KeyCode.G))
+            DecreaseSimulationSpeed();
+    }
+
+    private void DecreaseSimulationSpeed()
+    {
+        simulationSpeed *= 0.5f;
+        simulationSpeed = Mathf.Clamp(simulationSpeed, 0.03125f, 32.0f);
+        Citizen.SetSpeedCitizens(simulationSpeed);
+    }
+    private void IncreaseSimulationSpeed()
+    {
+        simulationSpeed *= 2.0f;
+        simulationSpeed = Mathf.Clamp(simulationSpeed, 0.03125f, 32.0f);
+        Citizen.SetSpeedCitizens(simulationSpeed);
+    }
+
+    private void CycleSimulationStates()
+    {
+        sim_state++;
+        if (sim_state >= SimState.TotalSimStates)
+            sim_state = SimState.Default;
     }
 
     private void CycleViewModes()
@@ -79,6 +123,7 @@ public class SimCore : MonoBehaviour
     // Time Control Methods
     public void PlaySimulation()
     {
+        sim_state = SimState.Running;
         isSimulationRunning = true;
         Citizen.EnableMovement(true);
         Debug.Log("Simulation Started");
@@ -90,6 +135,7 @@ public class SimCore : MonoBehaviour
 
     public void PauseSimulation()
     {
+        sim_state = SimState.Paused;
         isSimulationRunning = false;
         Citizen.EnableMovement(false);
         Debug.Log("Simulation Paused");


### PR DESCRIPTION
Citizens manage more of their own state, instead of that happening in Building.cs
Still using Legacy Save + Reload prefab hack for citizens, so the TODO for me is to swap that out.
Citizens are now correctly affected by Timescaling, except for a minor bug with collision at higher simulation speeds not being caught. Also TODO for me.